### PR TITLE
Feature normalize

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -10,6 +10,7 @@ class GraphvizHandler:
 
     graphvizグラフを操作する関数をまとめたクラス
     """
+
     def __init__(self):
         pass
 
@@ -47,6 +48,7 @@ class NetworkxHandler:
 
     networkxグラフを操作する関数をまとめたクラス
     """
+
     def __init__(self):
         self.graph = nx.DiGraph()
         self.source2targets = defaultdict(list)
@@ -105,7 +107,7 @@ class NetworkxHandler:
 
     def get_graph_edges(self):
         """get_graph_edges
-        
+
         networkxグラフのエッジを取得する関数(アトリビュートを含まない)
 
         Returns:
@@ -145,12 +147,12 @@ class NetworkxHandler:
 
     def get_ascendants(self, node):
         """get_ascendants
-        
+
         ノードの祖先全てを取得する関数
 
         Args:
             node (int): ノードID
-        
+
         Returns:
             (set): ノードの祖先のset
         """
@@ -167,12 +169,12 @@ class NetworkxHandler:
 
     def get_descendants(self, node):
         """get_descendants
-        
+
         ノードの子孫全てを取得する関数
 
         Args:
             node (int): ノードID
-        
+
         Returns:
             (set): ノードの子孫のset
         """
@@ -189,7 +191,7 @@ class NetworkxHandler:
 
     def get_orphans(self):
         """get_orphans
-        
+
         親ノードがないノードを取得する関数
 
         Returns:
@@ -203,7 +205,7 @@ class NetworkxHandler:
 
     def get_label(self, node):
         """get_label
-        
+
         ノードのラベルを取得する関数
 
         Args:
@@ -216,7 +218,7 @@ class NetworkxHandler:
 
     def set_label(self, node, label):
         """set_label
-        
+
         ノードのラベルを設定する関数
 
         Args:
@@ -232,7 +234,7 @@ class NetworkxHandler:
 
     def get_nodes(self, label):
         """get_nodes
-        
+
         ラベルからノードを取得する関数
 
         Args:
@@ -341,7 +343,7 @@ class NetworkxHandler:
 
     def add_child(self, parent, label, attr=None):
         """add_child
-        
+
         子ノードを追加する関数
 
         Args:

--- a/handler.py
+++ b/handler.py
@@ -243,19 +243,18 @@ class NetworkxHandler:
         """
         return self.label2nodes[label]
 
-    def get_attr(self, node, attr_key):
+    def get_attr(self, node):
         """get_attr
 
         ノードのアトリビュートを取得する関数
 
         Args:
             node (int): ノードID
-            attr_key (str): アトリビュートの種類
 
         Returns:
             (str): ノードのアトリビュート
         """
-        return self.node2attr[node][attr_key]
+        return self.node2attr[node]
 
     def get_all_nodes(self):
         """get_all_nodes

--- a/handler.py
+++ b/handler.py
@@ -152,7 +152,7 @@ class NetworkxHandler:
             node (int): ノードID
         
         Returns:
-            (list): ノードの祖先のリスト
+            (set): ノードの祖先のset
         """
         ascendants = set()
 
@@ -174,7 +174,7 @@ class NetworkxHandler:
             node (int): ノードID
         
         Returns:
-            (list): ノードの子孫のリスト
+            (set): ノードの子孫のset
         """
         decendants = set()
 
@@ -193,7 +193,7 @@ class NetworkxHandler:
         親ノードがないノードを取得する関数
 
         Returns:
-            (list): 親ノードがないノードのリスト
+            (set): 親ノードがないノードのset
         """
         orphans = set()
         for node, _ in self.get_graph_nodes():

--- a/handler.py
+++ b/handler.py
@@ -322,6 +322,7 @@ class NetworkxHandler:
         new_node = self.get_next_node()
         self.node2label[new_node] = label
         self.label2nodes[label].append(new_node)
+        self.node2attr[new_node] = attr
         self.graph.add_node(new_node, label=label, **attr)
         return new_node
 

--- a/handler.py
+++ b/handler.py
@@ -3,6 +3,7 @@ import json
 import networkx as nx
 import graphviz
 from networkx.readwrite import json_graph
+from copy import copy
 
 
 class GraphvizHandler:
@@ -88,7 +89,8 @@ class NetworkxHandler:
             label = attr["label"]
             self.node2label[node] = label
             self.label2nodes[label].append(node)
-            self.node2attr[node] = attr
+            self.node2attr[node] = copy(attr)
+            del self.node2attr[node]["label"]
 
     def get_graph_nodes(self):
         """get_graph_nodes

--- a/handler.py
+++ b/handler.py
@@ -197,10 +197,9 @@ class NetworkxHandler:
         Returns:
             (set): 親ノードがないノードのset
         """
-        orphans = set()
-        for node, _ in self.get_graph_nodes():
-            if not node in self.target2sources:
-                orphans.add(node)
+        all_nodes = set(self.graph.nodes())
+        not_orphans = set(self.target2sources.keys())
+        orphans = all_nodes.difference(not_orphans)
         return orphans
 
     def get_label(self, node):

--- a/handler.py
+++ b/handler.py
@@ -52,7 +52,7 @@ class NetworkxHandler:
         self.source2targets = defaultdict(list)
         self.target2sources = defaultdict(list)
         self.node2label = dict()
-        self.label2node = dict()
+        self.label2nodes = defaultdict(list)
         self.node2attr = dict()
 
     def load_json(self, path):
@@ -85,7 +85,7 @@ class NetworkxHandler:
         for node, attr in self.get_graph_nodes():
             label = attr["label"]
             self.node2label[node] = label
-            self.label2node[label] = node
+            self.label2nodes[label].append(node)
             self.node2attr[node] = attr
 
     def get_graph_nodes(self):
@@ -225,13 +225,13 @@ class NetworkxHandler:
         """
         previous_label = self.get_label(node)
         self.node2label[node] = label
-        del self.label2node[previous_label]
-        self.label2node[label] = node
+        self.label2nodes[previous_label].remove(node)
+        self.label2nodes[label].append(node)
         self.node2attr[node]["label"] = label
         self.graph[node]["label"] = label
 
-    def get_node(self, label):
-        """get_node
+    def get_nodes(self, label):
+        """get_nodes
         
         ラベルからノードを取得する関数
 
@@ -241,7 +241,7 @@ class NetworkxHandler:
         Returns:
             (int): ノードID
         """
-        return self.label2node[label]
+        return self.label2nodes[label]
 
     def get_attr(self, node, attr_key):
         """get_attr
@@ -322,7 +322,7 @@ class NetworkxHandler:
         """
         new_node = self.get_next_node()
         self.node2label[new_node] = label
-        self.label2node[label] = new_node
+        self.label2nodes[label].append(new_node)
         self.graph.add_node(new_node, label=label, **attr)
         return new_node
 
@@ -360,7 +360,8 @@ class NetworkxHandler:
         Args:
             node (int): 削除するノードID
         """
-        del self.label2node[self.node2label[node]]
+        label = self.get_label(node)
+        self.label2nodes[label].remove(node)
         del self.node2label[node]
         if node in self.source2targets:
             del self.source2targets[node]

--- a/handler.py
+++ b/handler.py
@@ -197,7 +197,7 @@ class NetworkxHandler:
         """
         orphans = set()
         for node, _ in self.get_graph_nodes():
-            if node in self.target2sources:
+            if not node in self.target2sources:
                 orphans.add(node)
         return orphans
 

--- a/handler.py
+++ b/handler.py
@@ -365,8 +365,14 @@ class NetworkxHandler:
         del self.node2label[node]
         if node in self.source2targets:
             del self.source2targets[node]
+        for source in self.source2targets:
+            if node in self.source2targets[source]:
+                self.source2targets[source].remove(node)
         if node in self.target2sources:
             del self.target2sources[node]
+        for target in self.target2sources:
+            if node in self.target2sources[target]:
+                self.target2sources[target].remove(node)
         self.graph.remove_node(node)
 
     def remove_edge(self, source, target):

--- a/handler.py
+++ b/handler.py
@@ -228,7 +228,7 @@ class NetworkxHandler:
         self.label2nodes[previous_label].remove(node)
         self.label2nodes[label].append(node)
         self.node2attr[node]["label"] = label
-        self.graph[node]["label"] = label
+        self.graph.nodes[node]["label"] = label
 
     def get_nodes(self, label):
         """get_nodes

--- a/normalize.py
+++ b/normalize.py
@@ -112,6 +112,7 @@ class Converter():
         return self.fof_tree.is_token(node) and not label == "!"
 
     def arrange_conjuction(self, output_nx):
+        assert len(output_nx.get_orphans()) == 1
         root = output_nx.get_orphans().pop()
         # Rootが & ではない
         if not "&" in output_nx.get_label(root):
@@ -136,6 +137,7 @@ class Converter():
                     merge_conjunction_recursively(child)
 
     def arrange_disjunction(self, output_nx):
+        assert len(output_nx.get_orphans()) == 1
         conjuction_node = output_nx.get_orphans().pop()
         for child in output_nx.get_children(conjuction_node):
             # & の子が | ではない
@@ -166,6 +168,7 @@ class Converter():
     def merge_negation(self, output_nx, node=None):
         # dfsで探索していき、notのノードがあれば子にnotを付与し、notノードを削除する
         if node is None:
+            assert len(output_nx.get_orphans()) == 1
             node = output_nx.get_orphans().pop()
         children = deepcopy(output_nx.get_children(node))
         for child in children:

--- a/normalize.py
+++ b/normalize.py
@@ -89,7 +89,8 @@ class Converter():
         if self.is_reserve_node(node, label):
             new_node = output_nx.get_next_node()
             last_node = new_node
-            output_nx.add_node(label)
+            attr = self.fof_tree.nx.get_attr(node)
+            output_nx.add_node(label, **attr)
             if parent_node is not None:
                 output_nx.add_edge(parent_node, new_node)
         else:
@@ -118,7 +119,7 @@ class Converter():
         if not "&" in output_nx.get_label(root):
             # Rootに & を追加する
             node = output_nx.get_next_node()
-            output_nx.add_node("&")
+            output_nx.add_node("&", token_type="AND_CONNECTIVE")
             output_nx.add_edge(node, root)
 
         else:
@@ -145,7 +146,7 @@ class Converter():
                 output_nx.remove_edge(conjuction_node, child)
                 # &の子に|を追加
                 next_node = output_nx.get_next_node()
-                output_nx.add_node("|")
+                output_nx.add_node("|", token_type="VLINE")
                 output_nx.add_edge(conjuction_node, next_node)
                 output_nx.add_edge(next_node, child)
             else:

--- a/normalize.py
+++ b/normalize.py
@@ -13,7 +13,7 @@ class DeductionTree:
     def collect_cnf_nodes_recursively(self, node, cnf_nodes, is_cnf=False):
         targets = self.nx.get_children(node)
         for target in targets:
-            inference_rule = self.nx.get_attr(target, "inference_rule")
+            inference_rule = self.nx.get_attr(target)["inference_rule"]
             is_already_added = False
             if is_cnf or inference_rule == "cnf_transformation":
                 is_cnf = True

--- a/normalize.py
+++ b/normalize.py
@@ -1,7 +1,6 @@
 from copy import deepcopy
 import json
 import os
-import networkx
 from networkx.readwrite import json_graph
 from handler import NetworkxHandler
 
@@ -124,7 +123,7 @@ class Converter():
             # dfsで探索し、& が再帰されて使用されている場合は統合する
             def merge_conjunction_recursively(node):
                 label = output_nx.get_label(node)
-                    if label == "&":
+                if label == "&":
                     children = deepcopy(output_nx.get_children(node))
                     for child in children:
                         output_nx.add_edge(root, child)
@@ -152,11 +151,11 @@ class Converter():
 
                 def merge_disjunction_recursively(node):
                     label = output_nx.get_label(node)
-                        if label == "|":
+                    if label == "|":
                         children = deepcopy(output_nx.get_children(node))
                         for child in children:
                             output_nx.add_edge(disjunction_node, child)
-                                merge_disjunction_recursively(child)
+                            merge_disjunction_recursively(child)
                         output_nx.remove_node(node)
 
                 grand_children = deepcopy(output_nx.get_children(child))
@@ -175,6 +174,6 @@ class Converter():
                 output_nx.remove_node(node)
                 if parents:
                     parent = parents[0]
-                output_nx.add_edge(parent, child)
+                    output_nx.add_edge(parent, child)
                 output_nx.set_label(child, "~" + output_nx.get_label(child))
             self.merge_negation(output_nx, child)

--- a/normalize.py
+++ b/normalize.py
@@ -1,0 +1,152 @@
+import json
+import os
+import networkx
+from networkx.readwrite import json_graph
+from handler import NetworkxHandler
+
+
+class DeductionTree:
+    def __init__(self, path):
+        self.nx = NetworkxHandler()
+        self.nx.load_json(path)
+
+    def collect_cnf_nodes_recursively(self, node, cnf_nodes, is_cnf=False):
+        targets = self.nx.get_children(node)
+        for target in targets:
+            inference_rule = self.nx.get_attr(target, "inference_rule")
+            is_already_added = False
+            if is_cnf or inference_rule == "cnf_transformation":
+                is_cnf = True
+                if target in cnf_nodes:
+                    is_already_added = True
+                cnf_nodes.add(target)
+            if not is_already_added:
+                self.collect_cnf_nodes_recursively(
+                    target, cnf_nodes, is_cnf)
+
+    def collect_cnf_nodes(self):
+        orphan_nodes = self.nx.get_orphans()
+        cnf_nodes = set()
+        for node in orphan_nodes:
+            self.collect_cnf_nodes_recursively(node, cnf_nodes)
+        return cnf_nodes
+
+
+class FofTree:
+    def __init__(self, path):
+        self.nx = NetworkxHandler()
+        self.nx.load_json(path)
+
+    def get_formula_root(self, fof_name):
+        node = self.nx.get_node(fof_name)
+        theorem_root = self.nx.get_parents(node)[0]
+        formula_root = self.nx.get_children(theorem_root)[2]
+        return formula_root
+
+
+class Converter():
+    def __init__(self, fof_json_path, deduction_tree_json_path):
+        self.fof_tree = FofTree(fof_json_path)
+        self.deduction_tree = DeductionTree(deduction_tree_json_path)
+
+    def save_normalized_formula(self, dir_path):
+        nodes = self.deduction_tree.collect_cnf_nodes()
+        for node in nodes:
+            formula_root = self.fof_tree.get_formula_root(node)
+            graph = self.normalize_formula(formula_root)
+            json_root = json_graph.node_link_data(graph)
+            fof_name = self.fof_tree.nx.get_label(node)
+            with open(os.path.join(dir_path, fof_name+".json"), "w") as f:
+                json.dump(json_root, f, indent=4)
+
+    def normalize_formula(self, formula_root):
+        output_graph = networkx.DiGraph()
+        output_nx = NetworkxHandler(output_graph)
+        self.remove_redundant_nodes(output_nx, formula_root)
+        self.arrange_conjuction(output_nx)
+        self.arrange_disjunction(output_nx)
+        self.merge_negation(output_nx)
+        return output_nx.get_graph()
+
+    def remove_redundant_nodes(self, output_nx, node, parent_node=None):
+        # 以下のノードを削除する
+        # 1.Quantifier情報が入っているノード
+        # 2.トークン情報が入っていないノード
+        label = self.fof_tree.nx.get_label(node)
+        if self.is_reserve_node(label):
+            reserve_node = output_nx.get_next_node()
+            output_nx.add_node(label)
+            if parent_node is not None:
+                output_nx.add_edge(parent_node, reserve_node)
+        for child in self.fof_tree.nx.get_children(node):
+            last_node = output_nx.get_last_node()
+            if "!" in label:
+                # 全称量化子の場合は右の子ノードのみを残す
+                second_child = self.fof_tree.nx.get_children(node)[1]
+                self.remove_redundant_nodes(
+                    output_nx, second_child, last_node)
+                break
+            else:
+                self.remove_redundant_nodes(output_nx, child, last_node)
+
+    def is_reserve_node(self, label):
+        return "," in label and not "!" in label
+
+    def arrange_conjuction(self, output_nx):
+        root = output_nx.get_orphans()[0]
+        # Rootが & ではない
+        if not "&" in output_nx.get_label(root):
+            # Rootに & を追加する
+            node = output_nx.get_next_node()
+            output_nx.add_node("&")
+            output_nx.add_edge(node, root)
+
+        else:
+            # dfsで探索し、& が再帰されて使用されている場合は統合する
+            def merge_conjunction_recursively(node):
+                for child in output_nx.get_children(node):
+                    label = output_nx.get_label(child)
+                    if label == "&":
+                        grand_children = output_nx.get_children(child)
+                        for grand_child in grand_children:
+                            output_nx.add_edge(root, grand_child)
+                            output_nx.remove_node(child)
+                            merge_conjunction_recursively(grand_child)
+            merge_conjunction_recursively(root)
+
+    def arrange_disjunction(self, output_nx):
+        conjuction_node = output_nx.get_orphans()[0]
+        for child in output_nx.get_children(conjuction_node):
+            # & の子が | ではない
+            if not "|" in output_nx.get_label(child):
+                # &の子に|を追加
+                next_node = output_nx.get_next_node()
+                output_nx.add_node("|")
+                output_nx.add_edge(conjuction_node, next_node)
+                output_nx.add_edge(next_node, child)
+            else:
+                # dfsで探索し、| が再帰されて使用されている場合は統合する
+                def merge_disjunction_recursively(node):
+                    for child in output_nx.get_children(node):
+                        label = output_nx.get_label(child)
+                        if label == "|":
+                            grand_children = output_nx.get_children(child)
+                            for grand_child in grand_children:
+                                output_nx.add_edge(node, grand_child)
+                                output_nx.remove_edge(child, grand_child)
+                                output_nx.remove_node(node)
+                                merge_disjunction_recursively(child)
+                merge_disjunction_recursively(child)
+
+    def merge_negation(self, output_nx, node=None):
+        # dfsで探索していき、notのノードがあれば子にnotを付与し、notノードを削除する
+        if node is None:
+            node = output_nx.get_orphans()[0]
+        for child in output_nx.get_children(node):
+            label = output_nx.get_label(node)
+            if label == "~":
+                output_nx.remove_node(node)
+                parent = output_nx.get_parents(node)[0]
+                output_nx.add_edge(parent, child)
+                output_nx.set_label(child, "~" + output_nx.get_label(child))
+            self.merge_negation(child)

--- a/normalize.py
+++ b/normalize.py
@@ -38,8 +38,7 @@ class FofTree:
         self.nx.load_json(path)
 
     def get_formula_root(self, fof_name):
-        node = self.nx.get_node(fof_name)
-        theorem_root = self.nx.get_parents(node)[0]
+        nodes = self.nx.get_nodes(fof_name)
         formula_root = self.nx.get_children(theorem_root)[2]
         return formula_root
 

--- a/normalize.py
+++ b/normalize.py
@@ -70,8 +70,7 @@ class Converter():
                 json.dump(json_root, f, indent=4)
 
     def normalize_formula(self, formula_root):
-        output_graph = networkx.DiGraph()
-        output_nx = NetworkxHandler(output_graph)
+        output_nx = NetworkxHandler()
         self.remove_redundant_nodes(output_nx, formula_root)
         self.arrange_conjuction(output_nx)
         self.arrange_disjunction(output_nx)

--- a/normalize.py
+++ b/normalize.py
@@ -39,8 +39,19 @@ class FofTree:
 
     def get_formula_root(self, fof_name):
         nodes = self.nx.get_nodes(fof_name)
+        name_node = None
+        for node in nodes:
+            attr = self.nx.get_attr(node)
+            if self.is_name_node(attr):
+                name_node = node
+        if name_node is None:
+            return None
+        theorem_root = self.nx.get_parents(name_node)[0]
         formula_root = self.nx.get_children(theorem_root)[2]
         return formula_root
+
+    def is_name_node(self, attr):
+        return "token_type" in attr and attr["token_type"] == "NAME"
 
 
 class Converter():
@@ -51,10 +62,10 @@ class Converter():
     def save_normalized_formula(self, dir_path):
         nodes = self.deduction_tree.collect_cnf_nodes()
         for node in nodes:
-            formula_root = self.fof_tree.get_formula_root(node)
+            fof_name = self.deduction_tree.nx.get_label(node)
+            formula_root = self.fof_tree.get_formula_root(fof_name)
             graph = self.normalize_formula(formula_root)
             json_root = json_graph.node_link_data(graph)
-            fof_name = self.fof_tree.nx.get_label(node)
             with open(os.path.join(dir_path, fof_name+".json"), "w") as f:
                 json.dump(json_root, f, indent=4)
 

--- a/normalize.py
+++ b/normalize.py
@@ -1,4 +1,4 @@
-from copy import deepcopy
+from copy import copy
 import json
 import os
 from networkx.readwrite import json_graph
@@ -127,13 +127,13 @@ class Converter():
             def merge_conjunction_recursively(node):
                 label = output_nx.get_label(node)
                 if label == "&":
-                    children = deepcopy(output_nx.get_children(node))
+                    children = copy(output_nx.get_children(node))
                     for child in children:
                         output_nx.add_edge(root, child)
                         merge_conjunction_recursively(child)
                     output_nx.remove_node(node)
 
-            children = deepcopy(output_nx.get_children(root))
+            children = copy(output_nx.get_children(root))
             for child in children:
                 merge_conjunction_recursively(child)
 
@@ -156,13 +156,13 @@ class Converter():
                 def merge_disjunction_recursively(node):
                     label = output_nx.get_label(node)
                     if label == "|":
-                        children = deepcopy(output_nx.get_children(node))
+                        children = copy(output_nx.get_children(node))
                         for child in children:
                             output_nx.add_edge(disjunction_node, child)
                             merge_disjunction_recursively(child)
                         output_nx.remove_node(node)
 
-                grand_children = deepcopy(output_nx.get_children(child))
+                grand_children = copy(output_nx.get_children(child))
                 for grand_child in grand_children:
                     merge_disjunction_recursively(grand_child)
 
@@ -171,7 +171,7 @@ class Converter():
         if node is None:
             assert len(output_nx.get_orphans()) == 1
             node = output_nx.get_orphans().pop()
-        children = deepcopy(output_nx.get_children(node))
+        children = copy(output_nx.get_children(node))
         for child in children:
             label = output_nx.get_label(node)
             if label == "~":

--- a/normalize.py
+++ b/normalize.py
@@ -132,9 +132,9 @@ class Converter():
                         merge_conjunction_recursively(child)
                     output_nx.remove_node(node)
 
-                children = deepcopy(output_nx.get_children(root))
-                for child in children:
-                    merge_conjunction_recursively(child)
+            children = deepcopy(output_nx.get_children(root))
+            for child in children:
+                merge_conjunction_recursively(child)
 
     def arrange_disjunction(self, output_nx):
         assert len(output_nx.get_orphans()) == 1

--- a/normalize.py
+++ b/normalize.py
@@ -84,19 +84,20 @@ class Converter():
         # 以下のノードを削除する
         # 1.Quantifier情報が入っているノード
         # 2.トークン情報が入っていないノード
+        # 型付きの論理式(tffなど)では変数の型情報が消える
         label = self.fof_tree.nx.get_label(node)
         if self.is_reserve_node(node, label):
-            reserve_node = output_nx.get_next_node()
-            last_node = reserve_node
+            new_node = output_nx.get_next_node()
+            last_node = new_node
             output_nx.add_node(label)
             if parent_node is not None:
-                output_nx.add_edge(parent_node, reserve_node)
+                output_nx.add_edge(parent_node, new_node)
         else:
             last_node = parent_node
         for child in self.fof_tree.nx.get_children(node):
-            if last_node == -1:
-                last_node = None
             if label == "!":
+                # logic_formulaだけが現れるケースには未対応
+                # 全称量化子の子がvariable_listのみのケースの場合
                 if len(self.fof_tree.nx.get_children(node)) == 1:
                     break
                 # 全称量化子の場合は右の子ノードのみを残す

--- a/parse_tstp.py
+++ b/parse_tstp.py
@@ -145,7 +145,7 @@ class ParseTstp():
 
     def __init__(self, grammar_path):
         self.grammar_path = grammar_path
-        
+
     def __satisfy_parent_condition(self, node_name, parent_node_name):
         """__satisfy_parent_condition
 
@@ -391,7 +391,7 @@ class ParseTstp():
 
     def get_inference_children(self, annotations_id, ast_handler):
         """get_inference_children
-        
+
         inferenceノードの子ノードを取得する関数
 
         Args:
@@ -408,7 +408,7 @@ class ParseTstp():
         inference = annotations_children[0]
         if not "inference" in ast_handler.get_label(inference):
             return []
-        
+
         return ast_handler.get_children(inference)
 
     def __get_inference_rule(self, annotations_id, ast_handler):
@@ -423,7 +423,8 @@ class ParseTstp():
         Returns:
             inference_rule (str): 式を導出するための操作名
         """
-        inference_children = self.get_inference_children(annotations_id, ast_handler)
+        inference_children = self.get_inference_children(
+            annotations_id, ast_handler)
         if not inference_children:
             return None
         inference_rule_node = inference_children[0]
@@ -442,7 +443,8 @@ class ParseTstp():
         Returns:
             assumption_formulas(list): 参照した式のノードのリスト
         """
-        inference_children = self.get_inference_children(annotations_id, ast_handler)
+        inference_children = self.get_inference_children(
+            annotations_id, ast_handler)
         if not inference_children:
             return []
         assumption_list = inference_children[-1]
@@ -471,17 +473,20 @@ class ParseTstp():
             formula_name_node = fof_children[0]
             annotations_node = fof_children[-1]
             formula_name = ast_handler.get_label(formula_name_node)
-            inference_rule = self.__get_inference_rule(annotations_node, ast_handler)
-            deduction_handler.add_node(formula_name, inference_rule=inference_rule)
+            inference_rule = self.__get_inference_rule(
+                annotations_node, ast_handler)
+            deduction_handler.add_node(
+                formula_name, inference_rule=inference_rule)
             assumption_formulas = self.__get_assumption_formulas(
                 annotations_node, ast_handler)
             for assumption_formula in assumption_formulas:
-                assumption_formula_label = ast_handler.get_label(assumption_formula)
+                assumption_formula_label = ast_handler.get_label(
+                    assumption_formula)
                 deduction_tree_edges.append(
                     (assumption_formula_label, formula_name))
         for source_label, target_label in deduction_tree_edges:
-            source = deduction_handler.get_node(source_label)
-            target = deduction_handler.get_node(target_label)
+            source = deduction_handler.get_nodes(source_label)[0]
+            target = deduction_handler.get_nodes(target_label)[0]
             deduction_handler.add_edge(source, target)
         graph = deduction_handler.get_graph()
         return graph


### PR DESCRIPTION
# 概要
* 抽象構文木と証明のグラフから、cnf標準形に直された式グラフを展開するクラスを作成しました
* 以下のような流れでグラフを展開しました
  1. 証明のグラフから、cnf標準形に直された式グラフを取得
  2. トークンノード以外、quantifier部分のノードを削除
  3. 論理積、論理和ノードを使用してない場合はノードの追加、入れ子になっている場合は展開
  4. 否定ノードは子ノードに付与し否定ノード自体は削除