### PR TITLE
Feature coordinate node

### DIFF
--- a/normalize.py
+++ b/normalize.py
@@ -77,6 +77,7 @@ class Converter():
         self.remove_redundant_nodes(output_nx, formula_root)
         self.arrange_conjuction(output_nx)
         self.arrange_disjunction(output_nx)
+        self.coordinate_node(output_nx)
         self.merge_negation(output_nx)
         return output_nx.get_graph()
 
@@ -166,6 +167,24 @@ class Converter():
                 grand_children = copy(output_nx.get_children(child))
                 for grand_child in grand_children:
                     merge_disjunction_recursively(grand_child)
+
+    def is_logic_symbol(self, label):
+        return label in {"&", "|", "~"}
+
+    def coordinate_node(self, output_nx):
+        label2nodes = copy(output_nx.label2nodes)
+        for label in label2nodes:
+            if not self.is_logic_symbol(label) and len(label2nodes[label]) > 1:
+                # 1つのラベルに複数のノードが存在する場合
+                # それらを結合するノードを追加する
+                token_type2node = dict()
+                for node in label2nodes[label]:
+                    token_type = output_nx.get_attr(node)["token_type"]
+                    if not token_type in token_type2node:
+                        new_node = output_nx.add_node(
+                            token_type, token_type="coodinate")
+                        token_type2node[token_type] = new_node
+                    output_nx.add_edge(node, token_type2node[token_type])
 
     def merge_negation(self, output_nx, node=None):
         # dfsで探索していき、notのノードがあれば子にnotを付与し、notノードを削除する

--- a/normalize.py
+++ b/normalize.py
@@ -182,7 +182,7 @@ class Converter():
                     token_type = output_nx.get_attr(node)["token_type"]
                     if not token_type in token_type2node:
                         new_node = output_nx.add_node(
-                            token_type, token_type="coodinate")
+                            token_type, token_type="coordinate")
                         token_type2node[token_type] = new_node
                     output_nx.add_edge(node, token_type2node[token_type])
 

--- a/normalize.py
+++ b/normalize.py
@@ -177,14 +177,12 @@ class Converter():
             if not self.is_logic_symbol(label) and len(label2nodes[label]) > 1:
                 # 1つのラベルに複数のノードが存在する場合
                 # それらを結合するノードを追加する
-                token_type2node = dict()
+                token_type = output_nx.get_attr(
+                    label2nodes[label][0])["token_type"]
+                new_node = output_nx.add_node(
+                    token_type, token_type="coordinate")
                 for node in label2nodes[label]:
-                    token_type = output_nx.get_attr(node)["token_type"]
-                    if not token_type in token_type2node:
-                        new_node = output_nx.add_node(
-                            token_type, token_type="coordinate")
-                        token_type2node[token_type] = new_node
-                    output_nx.add_edge(node, token_type2node[token_type])
+                    output_nx.add_edge(node, new_node)
 
     def merge_negation(self, output_nx, node=None):
         # dfsで探索していき、notのノードがあれば子にnotを付与し、notノードを削除する


### PR DESCRIPTION
# 概要

- 同じ種類のノードか分かるように1つのラベルに複数のノードが存在する場合それらを結合するノードを追加する関数を作成しました
- 統合するノードのラベルはトークンの型名にし，型はcoordinateとしています
    - 型に関しては統合するノードと分かれば良いと考えたためcoordinateとしています
- NetworkxHandlerのlabel2nodeを呼び出し，同じラベルのノードを呼び出し，ラベルが論理記号でないかつ長さが2以上の場合に統合するノードを追加するようにしています

![https://user-images.githubusercontent.com/54769649/195077902-044854c5-6a4c-4468-a8ae-51979b9fb845.png](https://user-images.githubusercontent.com/54769649/195077902-044854c5-6a4c-4468-a8ae-51979b9fb845.png)